### PR TITLE
Add settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ git clone https://github.com/Killerjet101/open-in-app.git
 
 ## Configuration
 By default all the listed apps will open in the desktop application but if you want to always open certain links in the browser you can easily do that.  
-For this go to your Discord settings, scroll down to the Powercord category, click on `OpenInApp` and toggle off any app that you don't want to open in the desktop app.  
+For this go to your Discord settings, go down to plugins, click on `OpenInApp` and toggle off any app that you don't want to open in the desktop app.  
 Having it on will open corresponding links in the desktop app and having it off will open the corresponding links like before.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ git clone https://github.com/Killerjet101/open-in-app.git
 - [ ] Epic Games
 - [ ] Origin
 - [ ] Twitch
+
+## Configuration
+By default all the listed apps will open in the desktop application but if you want to always open certain links in the browser you can easily do that.  
+For this go to your Discord settings, scroll down to the Powercord category, click on `OpenInApp` and toggle off any app that you don't want to open in the desktop app.  
+Having it on will open corresponding links in the desktop app and having it off will open the corresponding links like before.

--- a/components/Settings.jsx
+++ b/components/Settings.jsx
@@ -1,0 +1,30 @@
+const { React } = require('powercord/webpack');
+const { SwitchItem } = require('powercord/components/settings');
+
+module.exports = React.memo(
+  ({ getSetting, toggleSetting }) => (
+    <div>
+      <SwitchItem
+        note='Toggle whether Steam links should be opened in the app or not'
+        value={getSetting('open-in-app-steam', true)}
+        onChange={() => toggleSetting('open-in-app-steam')}
+      >
+        Steam
+      </SwitchItem>
+      <SwitchItem
+        note='Toggle whether Spotify links should be opened in the app or not'
+        value={getSetting('open-in-app-spotify', true)}
+        onChange={() => toggleSetting('open-in-app-spotify')}
+      >
+        Spotify
+      </SwitchItem>
+      <SwitchItem
+        note='Toggle whether Tidal links should be opened in the app or not'
+        value={getSetting('open-in-app-tidal', true)}
+        onChange={() => toggleSetting('open-in-app-tidal')}
+      >
+        Tidal
+      </SwitchItem>
+    </div>
+  )
+);


### PR DESCRIPTION
- Added Open In App to the settings page
- Added a toggle for Steam, Spotify and Tidal to let users choose whether each app should open in the corresponding app or not
- Updated README.md to reflect the changes